### PR TITLE
Separate dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
   ],
   "author": "Avraam Mavridis",
   "license": "ISC",
-  "devDependencies": {
-    "chai": "^2.0.0",
+  "dependencies": {
     "cli-color": "^0.3.2",
     "gulp-connect": "^2.2.0",
     "gulp-util": "^3.0.3",
     "joi": "^5.1.0",
-    "mocha": "^2.1.0",
     "phantomas": "^1.9.0"
+  },
+  "devDependencies": {
+    "chai": "^2.0.0",
+    "mocha": "^2.1.0"
   }
 }


### PR DESCRIPTION
`dependencies` are installed when this lib is included in other apps;
`devDependencies` are only installed when `npm install` is run inside of this directory.
